### PR TITLE
feat: enable external access for Prefect server with auto IP detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ poe format         # コードフォーマット
 poe typecheck      # 型チェック
 poe test           # テスト実行
 poe check          # 全チェック実行
-poe prefect-server # Prefectサーバー起動
+poe prefect-server # Prefectサーバー起動（IP自動検出、外部アクセス可能）
 poe prefect-flow   # Prefectフロー実行
 poe webgoat-start  # WebGoat起動
 poe webgoat-stop   # WebGoat停止
@@ -410,7 +410,7 @@ poe test-cov          # カバレッジ付き
 poe test-verbose      # 詳細出力
 
 # Prefect
-poe prefect-server    # Prefectサーバー起動
+poe prefect-server    # Prefectサーバー起動（IP自動検出、外部アクセス可能）
 poe prefect-flow      # サンプルフロー実行
 poe prefect-deploy    # フローデプロイ
 

--- a/docs/PREFECT.md
+++ b/docs/PREFECT.md
@@ -22,16 +22,70 @@ Prefectは、Pythonでデータパイプラインやワークフローを構築�
 
 ```bash
 # Prefectサーバーを起動（別ターミナルで実行）
-poe prefect-server
+# IPアドレスは自動検出されます
+uv run poe prefect-server
 ```
 
-サーバーが起動したら、ブラウザで http://127.0.0.1:4200 にアクセスしてダッシュボードを確認できます。
+起動時に以下のような情報が表示されます:
+```
+🚀 Starting Prefect server...
+📍 Local access:    http://127.0.0.1:4200
+🌐 External access: http://192.168.1.14:4200
+🔗 API URL:         http://192.168.1.14:4200/api
+```
+
+> ⚠️ **セキュリティ注意**: `--host 0.0.0.0`で起動すると外部からアクセス可能になります。本番環境では適切なファイアウォール設定やアクセス制御を行ってください。
 
 ### サンプルフローの実行
 
 ```bash
 # サンプルフローを実行
-poe prefect-flow
+uv run poe prefect-flow
+```
+
+---
+
+## 🌐 外部からのアクセス設定
+
+### サーバー側の設定
+
+Prefectサーバーは `--host 0.0.0.0` オプションで起動することで、外部からアクセス可能になります。
+
+**IPアドレスは自動検出されます** - 通常は何も設定する必要がありません:
+
+```bash
+# これだけでOK！IPアドレスは自動検出されます
+uv run poe prefect-server
+```
+
+起動時に表示される外部アクセスURLをブラウザで開くだけです。
+
+#### 手動で設定する場合（オプション）
+
+特定のIPアドレスを使いたい場合は、環境変数を設定できます:
+
+```bash
+export PREFECT_UI_API_URL="http://192.168.1.14:4200/api"
+uv run poe prefect-server
+```
+
+### クライアント側の設定
+
+外部のPrefectサーバーに接続する場合、環境変数を設定します:
+
+```bash
+# Prefect APIのエンドポイントを設定
+export PREFECT_API_URL="http://<サーバーのIPアドレス>:4200/api"
+
+# 設定を確認
+prefect config view
+```
+
+または、プロジェクトごとに設定する場合:
+
+```bash
+# プロジェクトのAPIエンドポイントを設定
+prefect config set PREFECT_API_URL="http://<サーバーのIPアドレス>:4200/api"
 ```
 
 ---
@@ -121,14 +175,14 @@ result = example_workflow(
 ### Prefect関連タスク
 
 ```bash
-# Prefectサーバー起動
-poe prefect-server
+# Prefectサーバー起動（外部アクセス可能）
+uv run poe prefect-server
 
 # サンプルフロー実行
-poe prefect-flow
+uv run poe prefect-flow
 
 # フローのデプロイ
-poe prefect-deploy
+uv run poe prefect-deploy
 ```
 
 ### その他のPrefect CLIコマンド

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -161,8 +161,18 @@ cmd = "pytest -v"
 # Prefect
 # ----------------------------------------
 [tool.poe.tasks.prefect-server]
-help = "Start Prefect server"
-cmd = "prefect server start"
+help = "Start Prefect server (accessible from external hosts)"
+shell = """
+# 自動的にローカルIPアドレスを検出
+LOCAL_IP=$(hostname -I | awk '{print $1}' || echo "127.0.0.1")
+export PREFECT_UI_API_URL="${PREFECT_UI_API_URL:-http://$LOCAL_IP:4200/api}"
+echo "🚀 Starting Prefect server..."
+echo "📍 Local access:    http://127.0.0.1:4200"
+echo "🌐 External access: http://$LOCAL_IP:4200"
+echo "🔗 API URL:         $PREFECT_UI_API_URL"
+echo ""
+prefect server start --host 0.0.0.0
+"""
 
 [tool.poe.tasks.prefect-flow]
 help = "Run example Prefect flow"


### PR DESCRIPTION
## Summary
- Prefectサーバーに外部からアクセスできるように設定を変更
- ローカルIPアドレスを自動検出する機能を追加
- 外部アクセス設定の詳細ドキュメントを追加
- セキュリティに関する警告を追加

## Changes
- **pyproject.toml**: `prefect-server`タスクを拡張し、IPアドレス自動検出とホスト0.0.0.0での起動を追加
- **docs/PREFECT.md**: 外部アクセス設定の詳細セクションを追加し、すべてのコマンドに`uv run`プレフィックスを追加
- **README.md**: Prefectサーバーの説明を更新

## Test plan
- [x] `uv run poe prefect-server`を実行してIPアドレスが正しく自動検出されることを確認
- [x] 表示されたローカルURL (http://127.0.0.1:4200) からアクセスできることを確認
- [x] 表示された外部URL (http://<LOCAL_IP>:4200) から別のデバイスでアクセスできることを確認
- [x] セキュリティ警告が適切に表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)